### PR TITLE
Clear browser cache only when logged in BrowserAuthenticationForm

### DIFF
--- a/Auth0.Windows/Auth0Client.cs
+++ b/Auth0.Windows/Auth0Client.cs
@@ -22,6 +22,8 @@ namespace Auth0.Windows
         private readonly string domain;
         private readonly string clientId;
 
+        private bool clearCache = true;
+
         internal string State { get; set; }
 
         public Auth0Client(string domain, string clientId)
@@ -134,6 +136,10 @@ namespace Auth0.Windows
                     throw ex;
                 }
 
+                //When the user signs in by directly without using the BrowserAuthenticationForm, we don't need
+                //to clear the cache.
+                this.clearCache = false;
+
                 return this.CurrentUser;
             });
         }
@@ -199,20 +205,20 @@ namespace Auth0.Windows
         /// <summary>
         /// Log a user out of a Auth0 application.
         /// </summary>
-        /// <param name="clearCache">Clear the browser cache.</param>
-        public void Logout(bool clearCache = true)
+        /// <param name="forceClearCache">Force clearing the browser cache, no matter the login method</param>
+        public void Logout(bool forceClearCache = false)
         {
             this.CurrentUser = null;
-            if(clearCache)
+            if(this.clearCache || forceClearCache)
                 WebBrowserHelpers.ClearCache();
         }
 
         /// <summary>
-        /// Log a user out of a Auth0 application and clear the browser cache.
+        /// Log a user out of a Auth0 application.
         /// </summary>
         public void Logout()
         {
-            Logout(true);
+            Logout(this.clearCache);
         }
 
         private void SetupCurrentUser(Auth0User auth0User)

--- a/Auth0.Windows/Auth0Client.cs
+++ b/Auth0.Windows/Auth0Client.cs
@@ -199,10 +199,20 @@ namespace Auth0.Windows
         /// <summary>
         /// Log a user out of a Auth0 application.
         /// </summary>
-        public void Logout()
+        /// <param name="clearCache">Clear the browser cache.</param>
+        public void Logout(bool clearCache = true)
         {
             this.CurrentUser = null;
-            WebBrowserHelpers.ClearCache();
+            if(clearCache)
+                WebBrowserHelpers.ClearCache();
+        }
+
+        /// <summary>
+        /// Log a user out of a Auth0 application and clear the browser cache.
+        /// </summary>
+        public void Logout()
+        {
+            Logout(true);
         }
 
         private void SetupCurrentUser(Auth0User auth0User)


### PR DESCRIPTION
The PR adds a private clearCache field to Auth0Client. 
clearCache is set to true by default. During Auth0Client.Logout, if clearCache is true --> clear the cache, otherwise not. 
clearCache is set to false when the login happens using the 
public Task<Auth0User> LoginAsync(string connection, string userName, string password, string scope = "openid") override i.e. by calling the oauth/ro endpoint directly without the BrowserAuthenticationForm.

Logout has an override with a forceClearCache parameter. If set to true, the cache is cleared, unregarded the private clearCache field, thus allowing to override the internal setting of the cache clearing.

Nothing fancy, but should fix issue #9 