### PR TITLE
Remove Flickering Auth form

### DIFF
--- a/samples/WinformsSample/WinformsSample.csproj
+++ b/samples/WinformsSample/WinformsSample.csproj
@@ -41,10 +41,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Auth0.Windows, Version=0.7.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Auth0.WinformsOrWPF.0.7.2\lib\net40\Auth0.Windows.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -94,7 +90,6 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <None Include="app.config" />
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -104,6 +99,12 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Auth0.Windows\Auth0.Windows.csproj">
+      <Project>{ffbfc9df-c380-4dab-9ea4-a98bafb186dc}</Project>
+      <Name>Auth0.Windows</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/samples/WinformsSample/packages.config
+++ b/samples/WinformsSample/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Auth0.WinformsOrWPF" version="0.7.2" targetFramework="net461" />
-</packages>

--- a/samples/WpfSample/WpfSample.csproj
+++ b/samples/WpfSample/WpfSample.csproj
@@ -43,10 +43,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Auth0.Windows, Version=0.7.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Auth0.WinformsOrWPF.0.7.3\lib\net40\Auth0.Windows.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -121,6 +117,12 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Auth0.Windows\Auth0.Windows.csproj">
+      <Project>{ffbfc9df-c380-4dab-9ea4-a98bafb186dc}</Project>
+      <Name>Auth0.Windows</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/samples/WpfSample/packages.config
+++ b/samples/WpfSample/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Auth0.WinformsOrWPF" version="0.7.3" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />

--- a/src/Auth0.Windows/Auth0Client.cs
+++ b/src/Auth0.Windows/Auth0Client.cs
@@ -53,6 +53,13 @@ namespace Auth0.Windows
         {
             var tcs = new TaskCompletionSource<Auth0User>();
             var auth = this.GetAuthenticator(connection, scope);
+            if (!string.IsNullOrEmpty(connection))
+            {
+                // If we have a connection name we don't want to display the login widget, but we still rely on it.
+                // So we set the position offscreen.
+                auth.StartPosition = FormStartPosition.Manual;
+                auth.Left = -10000;
+            }
 
             auth.Error += (o, e) =>
             {
@@ -97,15 +104,15 @@ namespace Auth0.Windows
         public Task<Auth0User> LoginAsync(string connection, string userName, string password, string scope = "openid")
         {
             var endpoint = string.Format(ResourceOwnerEndpoint, this.domain);
-            var parameters = new Dictionary<string, string> 
-			{
-				{ "client_id", this.clientId },
-				{ "connection", connection },
-				{ "username", userName },
-				{ "password", password },
-				{ "grant_type", "password" },
-				{ "scope", scope }
-			};
+            var parameters = new Dictionary<string, string>
+            {
+                { "client_id", this.clientId },
+                { "connection", connection },
+                { "username", userName },
+                { "password", password },
+                { "grant_type", "password" },
+                { "scope", scope }
+            };
 
             var request = new HttpClient();
             return request.PostAsync(new Uri(endpoint), new FormUrlEncodedContent(parameters)).ContinueWith(t =>
@@ -167,7 +174,7 @@ namespace Auth0.Windows
             }
 
             var endpoint = string.Format(DelegationEndpoint, this.domain);
-            var parameters = new Dictionary<string, string> 
+            var parameters = new Dictionary<string, string>
             {
                     { "grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer" },
                     { "id_token", id_token },
@@ -212,7 +219,7 @@ namespace Auth0.Windows
             }
             else
             {
-                this.SetupCurrentUser(new Dictionary<string, string> 
+                this.SetupCurrentUser(new Dictionary<string, string>
                 {
                     { "access_token", auth0User.Auth0AccessToken },
                     { "id_token", auth0User.IdToken },


### PR DESCRIPTION
When connection is passed into LoginAsync the login widget is bypassed, however it still shows for a short amount of time and creates a flicker effect.

I've also changed references in the sample projects to make testing easier.