### PR TITLE
Places the login widget offscreen when we don't want it to be displayed.

### DIFF
--- a/src/Auth0.Windows/Auth0Client.cs
+++ b/src/Auth0.Windows/Auth0Client.cs
@@ -53,6 +53,13 @@ namespace Auth0.Windows
         {
             var tcs = new TaskCompletionSource<Auth0User>();
             var auth = this.GetAuthenticator(connection, scope);
+            if (!string.IsNullOrEmpty(connection))
+            {
+                // If we have a connection name we don't want to display the login widget, but we still rely on it.
+                // So we set the position offscreen.
+                auth.StartPosition = FormStartPosition.Manual;
+                auth.Left = -10000;
+            }
 
             auth.Error += (o, e) =>
             {


### PR DESCRIPTION
When connection is passed into LoginAsync the embedded browser form is currently being displayed for a short amount of time creating a flicker effect.  To resolve I'm setting the form to be offscreen.